### PR TITLE
Update example MetricServer constructor arguments

### DIFF
--- a/MetricServer/CoreConsoleMetricServer_2.0/Program.cs
+++ b/MetricServer/CoreConsoleMetricServer_2.0/Program.cs
@@ -8,7 +8,12 @@ namespace CoreConsoleMetricServer
     {
         static void Main(string[] args)
         {
-            IMetricServer metricServer = new MetricServer("localhost", 9091);
+            var options = new MetricServerOptions
+            {
+                Port = 9091                
+            };
+            
+            IMetricServer metricServer = new MetricServer(Metrics.DefaultCollectorRegistry, _options);
             metricServer.Start();
 
             var counter = Metrics.CreateCounter("test_count", "helptext");


### PR DESCRIPTION
The MetricServer constructor arguments were out of date, actually requires a CollectorRegistry and MetricServerOptions object.